### PR TITLE
Monster Vote Form Improvements

### DIFF
--- a/src/components/nav/nav.html
+++ b/src/components/nav/nav.html
@@ -9,7 +9,7 @@
     </button>
 </div>
 <div id="nav-menu"
-    class="fixed md:mr-[300px] opacity-0 -translate-x-[248px] transition-all ease-in-out duration-300 top-0 left-0 w-full h-full max-w-[300px] bg-white shadow-lg font-semibold text-sf-grey-600">
+    class="fixed md:mr-[300px] opacity-0 -translate-x-[248px] transition-all ease-in-out duration-300 top-0 left-0 w-full h-full max-w-[300px] bg-white shadow-lg font-semibold text-sf-grey-600 z-40">
     <ul class="space-y-6 pt-8 px-6">
         <li>
             <a class="nav-menu-link hover:text-sf-orange-700" href="../../index.html">Home</a>

--- a/src/components/vote/vote.html
+++ b/src/components/vote/vote.html
@@ -1,5 +1,5 @@
 <div>
-  <div>
+  <div id="monster-vote-container">
     <form id="monster-vote-form">
       <div class="space-y-12">
         <div class="border-b border-gray-900/10 pb-12">
@@ -9,57 +9,58 @@
             </p>
           </div>
 
-          <fieldset id="monster-fieldset" class="min-w-full">
-            <legend class="text-sm font-semibold leading-6 text-gray-900">Favorite Monster</legend>
-            <p class="mt-1 text-sm leading-6 text-gray-600">Which Monster Was Your Favorite?</p>
-            <div id="monster-options"
-              class="my-8 min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-y-6 lg:gap-x-6">
-              <!--Monsters will be dynamically inserted here.-->
-            </div>
-          </fieldset>
-
-          <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-            <div class="sm:col-span-4">
-              <label for="name" class="block text-sm font-medium leading-6 text-gray-900">Name</label>
-              <div class="mt-2">
-                <input type="text" name="name" id="name" autocomplete="given-name"
-                  class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-sf-orange-600 sm:text-sm sm:leading-6">
-              </div>
-            </div>
-
-            <div class="sm:col-span-4">
-              <label for="email" class="block text-sm font-medium leading-6 text-gray-900">Email address</label>
-              <div class="mt-2">
-                <input id="email" name="email" type="email" autocomplete="email"
-                  class="required block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-sf-orange-600 sm:text-sm sm:leading-6">
-              </div>
-            </div>
-          </div>
-
-          <div class="mt-10 space-y-10">
-            <fieldset>
-              <legend class="text-sm font-semibold leading-6 text-gray-900">Contact Preferences</legend>
-              <div class="mt-6 space-y-6">
-                <div class="relative flex gap-x-3">
-                  <div class="flex h-6 items-center">
-                    <input id="contact_consent" name="contact_consent" type="checkbox" value="true"
-                      class="h-4 w-4 rounded border-gray-300 text-sf-orange-600 focus:ring-sf-orange-600">
-                  </div>
-                  <div class="text-sm leading-6">
-                    <label for="contact_consent" class="font-medium text-gray-900">I want to receive emails.</label>
-                    <p class="text-gray-500">Check to receive occasional emails from Stellmar Farm.</p>
-                  </div>
-                </div>
+          <div id="monster-vote-form-body">
+            <fieldset id="monster-fieldset" class="min-w-full">
+              <legend class="text-sm font-semibold leading-6 text-gray-900">Favorite Monster</legend>
+              <p class="mt-1 text-sm leading-6 text-gray-600">Which Monster Was Your Favorite?</p>
+              <div id="monster-options"
+                class="my-8 min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-y-6 lg:gap-x-6">
+                <!--Monsters will be dynamically inserted here.-->
               </div>
             </fieldset>
 
+            <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+              <div class="sm:col-span-4">
+                <label for="name" class="block text-sm font-medium leading-6 text-gray-900">Name</label>
+                <div class="mt-2">
+                  <input required id="name" name="name" type="text" autocomplete="given-name"
+                    class="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-sf-orange-600 sm:text-sm sm:leading-6">
+                </div>
+              </div>
+
+              <div class="sm:col-span-4">
+                <label for="email" class="block text-sm font-medium leading-6 text-gray-900">Email address</label>
+                <div class="mt-2">
+                  <input required id="email" name="email" type="email" autocomplete="email"
+                    class="required block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-sf-orange-600 sm:text-sm sm:leading-6">
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-10 space-y-10">
+              <fieldset>
+                <legend class="text-sm font-semibold leading-6 text-gray-900">Contact Preferences</legend>
+                <div class="mt-6 space-y-6">
+                  <div class="relative flex gap-x-3">
+                    <div class="flex h-6 items-center">
+                      <input id="contact_consent" name="contact_consent" type="checkbox" value="true"
+                        class="h-4 w-4 rounded border-gray-300 text-sf-orange-600 focus:ring-sf-orange-600">
+                    </div>
+                    <div class="text-sm leading-6">
+                      <label for="contact_consent" class="font-medium text-gray-900">I want to receive emails.</label>
+                      <p class="text-gray-500">Check to receive occasional emails from Stellmar Farm.</p>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+
+            </div>
           </div>
         </div>
       </div>
 
-      <div class="mt-6 flex items-center justify-end gap-x-6">
-        <!-- TODO: remove cancel button -->
-        <button type="reset" class="text-sm font-semibold leading-6 text-gray-900">Cancel</button>
+      <div id="monster-vote-form-buttons" class="mt-6 flex items-center justify-end gap-x-6">
+        <button type="reset" class="text-sm font-semibold leading-6 text-gray-900">Reset</button>
         <button type="submit" id="monster-form-submit"
           class="rounded-md bg-sf-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sf-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sf-orange-600">Vote</button>
       </div>

--- a/src/components/vote/vote.js
+++ b/src/components/vote/vote.js
@@ -67,13 +67,13 @@ class Vote extends HTMLElement {
     buildMonsterOption(json) {
         const html = `
         <div class="peer w-48 lg:w-60 relative place-self-center justify-self-center peer-has-[>input:checked]:opacity-50 has-[~div>input:checked]:opacity-50">
-            <input id="monster-${json.id}" name="favorite_monster" value="${json.id}" type="radio" class="peer hidden">
+            <input required id="monster-${json.id}" name="favorite_monster" value="${json.id}" type="radio" class="peer relative top-8 left-8 z-0">
             <label for="monster-${json.id}"
                 class="relative peer-checked:ring-4 peer-checked:ring-sf-orange-600 rounded-lg block text-sm font-medium leading-6">
-            <img class="relative w-48 lg:w-60 h-72 object-cover overflow-hidden bg-sf-red-50 rounded-lg z-0"
+            <img class="relative w-48 lg:w-60 h-72 object-cover overflow-hidden bg-sf-red-50 rounded-lg z-10"
                 src="${json.image_url}"
                 alt="A picture of the ${json.name} monster created by ${json.business}">
-            <div class="absolute bottom-0 bg-sf-grey-900/70 text-white w-full rounded-b-lg py-2 px-4">
+            <div class="absolute bottom-0 bg-sf-grey-900/70 text-white w-full rounded-b-lg py-2 px-4 z-20">
                 <span class="block text-sf-grey-100 -mb-1 z-20">${json.business}</span>
                 <div class="flex justify-between">
                 <span class="block font-semibold text-xl z-20">${json.name}</span>
@@ -85,8 +85,42 @@ class Vote extends HTMLElement {
         return html;
     }
 
+    buildSuccessMessage() {
+        return `
+            <div class="min-h-screen flex flex-col justify-center">
+                <div class="py-8">
+                    <h1 class="text-3xl md:text-4xl text-sf-green-700">Success! Thank you.</h1>
+                    <p>Your vote has been counted.</p>
+                </div>
+                <div class="py-8">
+                    <a class="rounded-md bg-sf-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sf-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sf-orange-600" href="index.html">Back to Stellmar Farm →</a>
+                    </div>
+                <br><br>
+                </div>
+            </div>
+        `;
+    }
+
+    buildErrorMessage() {
+        return `
+            <div class="min-h-screen flex flex-col justify-center">
+                <div class="py-8">
+                    <h1 class="text-3xl md:text-4xl text-sf-red-700">Sorry! Something went wrong.</h1>
+                    <p>Please try again later or <a class="underline hover:text-sf-orange-700" href="mailto:info@stellmarfarm.com">contact us</a>.</p>
+                </div>
+                <div class="py-8">
+                    <a class="rounded-md bg-sf-orange-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sf-orange-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sf-orange-600" href="index.html">Back to Stellmar Farm →</a>
+                    </div>
+                <br><br>
+                </div>
+            </div>
+        `;
+    }
+
     async submitForm(base_url, anon_key) {
         const url = `${base_url}/rest/v1/votes`;
+        
+        const formContainer = document.getElementById('monster-vote-container');
 
         // Get form data.
         const form = document.getElementById('monster-vote-form');
@@ -94,8 +128,6 @@ class Vote extends HTMLElement {
         const object = {};
         formData.forEach((value, key) => object[key] = value);
         const formJson = object
-        // TODO: remove logging.
-        console.log(formJson)
 
         try {
             const response = await fetch(url, {
@@ -108,22 +140,25 @@ class Vote extends HTMLElement {
                 body: JSON.stringify(formJson)
             });
 
-            if (!response.ok) {
-                throw new Error(`Response status: ${response.status}`);
-            }
-
             // Reset the form state.
             form.reset();
-            // TODO: show a success message to the user.
-            //var xhttp = new XMLHttpRequest();
-            //xhttp.open("GET", "demo.html", true);
-            //xhttp.send();
-            window.open("demo.html");
-            
+
+            // Replace the form with success or error message.
+            if (response.ok) {
+                // 200 response from API, show success message.
+                formContainer.innerHTML = this.buildSuccessMessage();
+            }
+            else {
+                // Something went wrong, show error message.
+                formContainer.innerHTML = this.buildErrorMessage();
+            }
+
+            // Make sure the user can see the message.
+            window.scrollTo({top: 0});
 
         } catch (error) {
-            // TODO: show an error message to the user.
-            console.error(error.message);
+                // Something went wrong, show error message.
+                formContainer.innerHTML = this.buildErrorMessage();
         }
     }
 }

--- a/src/components/vote/vote.js
+++ b/src/components/vote/vote.js
@@ -66,10 +66,10 @@ class Vote extends HTMLElement {
     // Note: nothing is escaped or sanitized, input is assumed trusted.
     buildMonsterOption(json) {
         const html = `
-        <div class="w-48 lg:w-60 relative place-self-center justify-self-center">
+        <div class="peer w-48 lg:w-60 relative place-self-center justify-self-center peer-has-[>input:checked]:opacity-50 has-[~div>input:checked]:opacity-50">
             <input id="monster-${json.id}" name="favorite_monster" value="${json.id}" type="radio" class="peer hidden">
             <label for="monster-${json.id}"
-            class="relative peer-checked:ring-4 peer-checked:ring-sf-orange-600 rounded-lg block text-sm font-medium leading-6">
+                class="relative peer-checked:ring-4 peer-checked:ring-sf-orange-600 rounded-lg block text-sm font-medium leading-6">
             <img class="relative w-48 lg:w-60 h-72 object-cover overflow-hidden bg-sf-red-50 rounded-lg z-0"
                 src="${json.image_url}"
                 alt="A picture of the ${json.name} monster created by ${json.business}">


### PR DESCRIPTION
- When a monster is selected, non-selected monsters have their opacity reduced to emphasize the selection.

> Because of the way the [Subsequent-sibling combinator](https://developer.mozilla.org/en-US/docs/Web/CSS/Subsequent-sibling_combinator) works in CSS, I had to use two TailwindCSS classes to give siblings the opacity when a radio is checked, one for previous siblings (`has-[~div>input:checked]:opacity-50`) and one for subsequent siblings (`peer-has-[>input:checked]:opacity-50`).

- When a user clicks "Vote" (the form submit button), the browser will do basic validation for the inputs marked with `required`; I made Monster, Name and Email Address required in this way. I tested firefox and chromium, it seems to do the job.

- After successful form submission,
    -  if the API returns a 200 response, a success message is shown,
    - otherwise an error message (with a contact link) is shown.

> I don't think it's a good idea to validate email uniqueness on this form. Rather, we can accept as many votes as a person wants to submit, and write a SQL query to group by email address and discard all but the most recent vote.